### PR TITLE
Dev admin bar overlaps content

### DIFF
--- a/hm-dev.plugin.php
+++ b/hm-dev.plugin.php
@@ -55,6 +55,10 @@ add_filter( 'admin_bar_menu', function() use ( $dev_title ) {
  */
 function hm_dev_colorize() { ?>
 <style>
+	
+	html.wp-toolbar { 
+		margin-top: 5px; 
+	}
 
 	#wpadminbar {
 		border-top: 5px solid rgba(193, 39, 45, 1);


### PR DESCRIPTION
5px border added by dev site indicator makes the admin bar larger than the 28px. WP adds 28px padding to html element. This is no longer enough
