### PR TITLE
Add hm-dev class to body

### DIFF
--- a/hm-dev.plugin.php
+++ b/hm-dev.plugin.php
@@ -74,8 +74,15 @@ function hm_dev_colorize() { ?>
 add_filter( 'admin_head', 'hm_dev_colorize' );
 add_filter( 'wp_head', 'hm_dev_colorize' );
 
+/**
+ * Add HM-Dev Body Class
+ *
+ * Filter body class and add hm-dev
+ * 
+ * @param  array $classes
+ * @return array $classes
+ */
 function hm_dev_body_class( $classes ) {
 	return array_merge( $classes, array( 'hm-dev' ) );
 }
-
 add_filter( 'body_class', 'hm_dev_body_class' );


### PR DESCRIPTION
Use case: HM Dev now adds a red bar above the admin bar - which makes the bar 5px taller. My fixed position header is now hidden underneath, and looks wrong. 

This is such a minor thing, but I thought there would be no harm having hm-dev add a class, so I can make it look right.
